### PR TITLE
Add scan uploading page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"jszip": "^3.10.1",
 				"node-fetch": "^3.3.2",
 				"openai": "^4.12.4",
+				"qr-scanner": "^1.4.2",
 				"qrcode": "^1.5.3",
 				"rehype-stringify": "^9.0.3",
 				"svelte-drawer-component": "^1.2.2",
@@ -971,6 +972,11 @@
 				"@types/node": "*",
 				"form-data": "^4.0.0"
 			}
+		},
+		"node_modules/@types/offscreencanvas": {
+			"version": "2019.7.3",
+			"resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+			"integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
 		},
 		"node_modules/@types/parse5": {
 			"version": "6.0.3",
@@ -5248,6 +5254,14 @@
 			},
 			"bin": {
 				"purgecss": "bin/purgecss.js"
+			}
+		},
+		"node_modules/qr-scanner": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/qr-scanner/-/qr-scanner-1.4.2.tgz",
+			"integrity": "sha512-kV1yQUe2FENvn59tMZW6mOVfpq9mGxGf8l6+EGaXUOd4RBOLg7tRC83OrirM5AtDvZRpdjdlXURsHreAOSPOUw==",
+			"dependencies": {
+				"@types/offscreencanvas": "^2019.6.4"
 			}
 		},
 		"node_modules/qrcode": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"jszip": "^3.10.1",
 		"node-fetch": "^3.3.2",
 		"openai": "^4.12.4",
+		"qr-scanner": "^1.4.2",
 		"qrcode": "^1.5.3",
 		"rehype-stringify": "^9.0.3",
 		"svelte-drawer-component": "^1.2.2",

--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -1,9 +1,19 @@
 <script>
 	import JSZip from "jszip";
 	import { uploadImage } from "$lib/supabase";
+	import { onMount } from "svelte";
+	import QrScanner from "qr-scanner";
 
-	let files;
-	let processedFiles = [];
+	// When rendering to canvas, the scaling we use.
+	const PDF_SCALE = 2.0;
+	// Location in pts of the top right qr code
+	const TEST_ID_PAGE_BOX = { left: 465, top: 14, width: 70, height: 70 };
+	// Location in pts of the sticker qr code (test taker ID)
+	const FRONT_ID_BOX = { left: 335, top: 130, width: 57.6, height: 57.6 };
+	// How many pts to expand the bounding boxes when looking to recognize the qr codes.
+	const QR_SEARCH_PADDING = 50;
+
+	let files = [];
 
 	$: if (files) {
 		(async () => {
@@ -11,69 +21,212 @@
 		})();
 	}
 
+	function initializePDFJS() {
+		let pdf_js_loaded = new Promise(async (resolve, reject) => {
+			let counter = 0;
+			function is_pdf_js_loaded() {
+				if (typeof pdfjsLib !== "undefined") {
+					resolve();
+				} else {
+					counter += 1;
+					// 10 seconds later, if pdf js has not loaded, throw an error.
+					if (counter > 100) {
+						reject("PDF.js did not load in 10 seconds.");
+					}
+					// Every .1 seconds
+					setTimeout(is_pdf_js_loaded, 100);
+				}
+			}
+			is_pdf_js_loaded();
+		});
+
+		pdf_js_loaded.then(() => {
+			console.log("pdf.js loaded");
+			pdfjsLib.GlobalWorkerOptions.workerSrc =
+				"https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.worker.min.mjs";
+		});
+	}
+
+	onMount(initializePDFJS);
+
 	async function handleFileUpload() {
-		console.log(files);
 		const filesToProcess = [];
-		for (let i = 0; i < files.length; i++) {
-			const file = files[i];
+		for (const file of files) {
 			if (
 				file.type === "application/zip" ||
 				file.type === "application/x-zip-compressed"
 			) {
-				//console.log("zip found");
 				filesToProcess.push(...(await unzipFile(file)));
-				//console.log("zip handled");
 			} else {
 				filesToProcess.push(file);
-				// Perform your desired action on individual processedFiles
-				// For example: processFile(file);
 			}
-			// console.log(i); // The value of i is not increasing because it is inside an asynchronous function
 		}
-		for (let i = 0; i < filesToProcess.length; i++) {
-			const file = filesToProcess[i];
-			await uploadImage(file);
+
+		let pngs = (
+			await Promise.all(
+				filesToProcess.map(
+					async (file) => await convertToPngs(await file.arrayBuffer())
+				)
+			)
+		).flat(1);
+		const expand_box = (bounding_box) => {
+			const b = bounding_box;
+			return {
+				x: (b.left - QR_SEARCH_PADDING) * PDF_SCALE,
+				y: (b.top - QR_SEARCH_PADDING) * PDF_SCALE,
+				width: (b.width + 2 * QR_SEARCH_PADDING) * PDF_SCALE,
+				height: (b.height + 2 * QR_SEARCH_PADDING) * PDF_SCALE,
+			};
+		};
+
+		const scan_box = (png, bounding_box) => {
+			return new Promise((resolve, reject) =>
+				QrScanner.scanImage(png, {
+					scanRegion: expand_box(bounding_box),
+					returnDetailedScanResult: true,
+				})
+					.then(resolve)
+					.catch((e) => reject(e || "No QR code found"))
+			);
+		};
+		const scan_boxes = async (png, test_id_page_box, front_id_box) => {
+			const { data: test_id_page } = await scan_box(png, test_id_page_box);
+			const { data: front_id } = await scan_box(png, front_id_box);
+			return [test_id_page, front_id, png];
+		};
+
+		for (const png of pngs) {
+			// Try to get either the top right or the bottom left qr boxes.
+			const [test_id_page, front_id, matched_png] = await Promise.any([
+				scan_boxes(png[0], TEST_ID_PAGE_BOX, FRONT_ID_BOX),
+				scan_boxes(png[1], TEST_ID_PAGE_BOX, FRONT_ID_BOX),
+			]);
+
+			// Assert that the test id matches a certain pattern.
+			if (!test_id_page.match(/T\d+P\d+/)) {
+				throw "Expected test and page id in T\\d+P\\d+ format.";
+			}
+			const [start, end] = test_id_page.split("P");
+			const test_id = start.substr(1);
+			// Convert from 1 indexed to 0 indexed.
+			const page = parseInt(end) - 1;
+
+			console.log(test_id_page, front_id);
+			uploadImage(matched_png, test_id, page.toString(), front_id);
+			// TODO: mark scan_path in scans table
 		}
 	}
 
 	async function unzipFile(zipFile) {
 		const zip = new JSZip();
 		const zipData = await zip.loadAsync(zipFile);
-		const promises = [];
 
-		console.log(zipData);
+		const fileList = [];
+		zipData.forEach(async (relativePath, zipEntry) =>
+			fileList.push([relativePath, zipEntry])
+		);
 
-		zipData.forEach(async (relativePath, zipEntry) => {
-			const promise = new Promise(async (resolve, reject) => {
-				const extractedFileData = await zipEntry.async("arraybuffer");
-				const extractedFile = new File([extractedFileData], zipEntry.name);
-				console.log(extractedFile);
-				resolve(extractedFile);
+		// Mac Finder-generated zip files contain extra __MACOSX files that are redundant.
+		const extracted_files = fileList
+			.filter(
+				([_, zipEntry]) =>
+					!zipEntry.dir &&
+					!zipEntry.name.startsWith("__MACOSX") &&
+					zipEntry.name.endsWith(".pdf")
+			)
+			.map(([_relativePath, zipEntry]) => {
+				return new Promise(async (resolve, _reject) => {
+					const extractedFileData = await zipEntry.async("arraybuffer");
+					const extractedFile = new File([extractedFileData], zipEntry.name);
+					resolve(extractedFile);
+				});
 			});
-			promises.push(promise);
-		});
 
-		return Promise.all(promises);
+		return Promise.all(extracted_files);
 	}
 
-	async function processFile(file) {
-		// Presumably do something here to process the files/turn into JPEGs, etc.
-		console.log("Now processing the file:", file.name);
+	// Returns the rendered PDF file as a blob and as rotated.
+	function convertToPngs(file) {
+		const loadingTask = pdfjsLib.getDocument({ data: new Uint8Array(file) });
 
+		const convert_page_to_png = async (page, canvasdiv) => {
+			const scale = 2.0;
+			const viewport = page.getViewport({ scale: scale });
+
+			const canvas = document.createElement("canvas");
+			canvasdiv.appendChild(canvas);
+
+			// Prepare canvas using PDF page dimensions
+			const context = canvas.getContext("2d");
+			canvas.height = viewport.height;
+			canvas.width = viewport.width;
+
+			// Render PDF page into canvas context
+			const renderContext = { canvasContext: context, viewport: viewport };
+
+			const renderTask = page.render(renderContext);
+			const [blob, rotated_blob] = await renderTask.promise.then(async () => {
+				const unrotated = await new Promise((resolve) => {
+					canvas.toBlob(resolve);
+				});
+				context.translate(canvas.width / 2, canvas.height / 2);
+				context.rotate(Math.PI);
+				context.drawImage(
+					context.canvas,
+					0,
+					0,
+					canvas.width,
+					canvas.height,
+					-canvas.width / 2,
+					-canvas.height / 2,
+					canvas.width,
+					canvas.height
+				);
+
+				const rotated = await new Promise((resolve) => {
+					canvas.toBlob(resolve);
+				});
+				return [unrotated, rotated];
+			});
+
+			canvas.remove();
+			return [blob, rotated_blob];
+		};
+
+		return loadingTask.promise.then(
+			async (pdf) => {
+				const canvas_div = document.getElementById("canvas");
+				const totalPages = pdf.numPages;
+				console.log(`processing ${totalPages} pages`);
+				let data = [];
+
+				for (let pageNumber = 1; pageNumber <= totalPages; pageNumber++) {
+					let page = await pdf.getPage(pageNumber);
+					data.push(await convert_page_to_png(page, canvas_div));
+				}
+				return data;
+			},
+			function (reason) {
+				// PDF loading error
+				console.error(reason);
+			}
+		);
 	}
 </script>
 
+<head>
+	<script
+		type="module"
+		src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.0.379/pdf.min.mjs"
+	></script>
+</head>
+
 <label>
 	Upload Files:
-	<input type="file" multiple bind:files />
+	<input type="file" multiple bind:files accept=".pdf,.zip" />
 </label>
 
-{#if processedFiles.length > 0}
-	<h2>Selected processedFiles:</h2>
-	{#each processedFiles as file}
-		<p>{file.name} ({file.size} bytes)</p>
-	{/each}
-{/if}
+<div id="canvas" style="display: none;" />
 
 <style>
 	/* Your CSS styles here */

--- a/src/lib/supabase/images.ts
+++ b/src/lib/supabase/images.ts
@@ -1,7 +1,5 @@
 import { supabase } from "../supabaseClient";
 
-
-
 /**
  * Fetches image from path
  *
@@ -49,14 +47,24 @@ export async function deleteImages(filePaths: string[]) {
  * @param file
  * @param upsert optional, boolean
  */
-export async function uploadImage(file: any) {
-	console.log(file);
-
-	let { error } = await supabase.storage
+export async function uploadImage(
+	file: any,
+	test_id: string,
+	page_number: string,
+	front_id: string,
+) {
+	let { data, error } = await supabase.storage
 		.from("scans")
-		.upload('test_1/test-file.jpg', file, {
+		.upload(`test_${test_id}/${front_id}/page_${page_number}.png`, file, {
 			upsert: true,
-		  });
+		});
+	// // TODO: update database schema, test uploading
+	// let { error } = await supabase.from("scans").upsert(
+	// 	{ test_id, taker_id: front_id, page_number, scan_path: data.path },
+	// 	{
+	// 		onConflict: "test_id,taker_id,page_number",
+	// 	},
+	// );
 	if (error) throw error;
 }
 
@@ -71,6 +79,6 @@ export async function getImageURL(filePath: string) {
 		.from("problem-images")
 		.getPublicUrl(filePath);
 	if (error) throw error;
-	
+
 	return data.publicURL;
 }

--- a/src/lib/supabase/images.ts
+++ b/src/lib/supabase/images.ts
@@ -53,19 +53,20 @@ export async function uploadImage(
 	page_number: string,
 	front_id: string,
 ) {
-	let { data, error } = await supabase.storage
+	let { data, error: upload_error } = await supabase.storage
 		.from("scans")
 		.upload(`test_${test_id}/${front_id}/page_${page_number}.png`, file, {
 			upsert: true,
 		});
-	// // TODO: update database schema, test uploading
-	// let { error } = await supabase.from("scans").upsert(
-	// 	{ test_id, taker_id: front_id, page_number, scan_path: data.path },
-	// 	{
-	// 		onConflict: "test_id,taker_id,page_number",
-	// 	},
-	// );
-	if (error) throw error;
+	if (upload_error) throw upload_error;
+
+	let { error: upsert_error } = await supabase.from("scans").upsert(
+		{ test_id, taker_id: front_id, page_number, scan_path: data.path },
+		{
+			onConflict: "test_id,taker_id,page_number",
+		},
+	);
+	if (upsert_error) throw upsert_error;
 }
 
 /**

--- a/src/routes/tests/[id]/answer_sheet.typ
+++ b/src/routes/tests/[id]/answer_sheet.typ
@@ -154,7 +154,8 @@
 
 // Generate boxes and measure them.
 #{
-  columns(3, gutter: 11pt, range(problem_count).map(i => {
+  let answer_box_column_count = 3
+  columns(answer_box_column_count, gutter: 11pt, range(problem_count).map(i => {
     layout(size => {
       style(styles => {
         let elem = answer_box(i, size)


### PR DESCRIPTION
Recognizes qr codes on tests, correcting for rotation if necessary. 
Uploads to supabase `scans` bucket with a path similar to `test/taker_id/page.png` (check code for details).
